### PR TITLE
Add metric for canceled events

### DIFF
--- a/exporter/event_handler.go
+++ b/exporter/event_handler.go
@@ -58,6 +58,9 @@ func (h *eventHandler) HandleEvent(msg *redis.Message) error {
 
 	case lockedEvent:
 		h.metrics.Locked.WithLabelValues(evt.TaskName).Inc()
+
+	case canceledEvent:
+		h.metrics.Canceled.WithLabelValues(evt.TaskName).Inc()
 	}
 	return nil
 }

--- a/exporter/event_handler_test.go
+++ b/exporter/event_handler_test.go
@@ -105,6 +105,23 @@ func Test_eventHandler_HandleEvent(t *testing.T) {
 			t.Errorf("executing: want:%v, got:%v", want, got)
 		}
 	})
+
+	t.Run(string(canceledEvent), func(t *testing.T) {
+		evt.Event = canceledEvent
+
+		msg := evtToMessage(evt)
+
+		want := testutil.ToFloat64(m.Canceled.WithLabelValues(evt.TaskName)) + 1
+
+		_ = h.HandleEvent(msg)
+
+		got := testutil.ToFloat64(m.Canceled.WithLabelValues(evt.TaskName))
+
+		if got != want {
+			t.Errorf("executing: want:%v, got:%v", want, got)
+		}
+	})
+
 }
 
 func evtToMessage(evt event) *redis.Message {

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -5,6 +5,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // Metrics stores all the metrics exposed by the exporter
 type Metrics struct {
 	Executions   *prometheus.CounterVec
+	Canceled     *prometheus.CounterVec
 	Completed    *prometheus.CounterVec
 	Locked       *prometheus.CounterVec
 	Duration     *prometheus.HistogramVec
@@ -20,6 +21,12 @@ func SetupMetrics(prefix string) *Metrics {
 			Subsystem: "scheduler",
 			Name:      "task_execution_total",
 			Help:      "The Number of times a scheduler task has been executed.",
+		}, []string{"task_name"}),
+		Canceled: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prefix,
+			Subsystem: "scheduler",
+			Name:      "task_canceled_total",
+			Help:      "The Number of times a scheduler task has been canceled.",
 		}, []string{"task_name"}),
 		Completed: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: prefix,
@@ -48,6 +55,7 @@ func SetupMetrics(prefix string) *Metrics {
 	}
 
 	prometheus.MustRegister(m.Executions)
+	prometheus.MustRegister(m.Canceled)
 	prometheus.MustRegister(m.Completed)
 	prometheus.MustRegister(m.Locked)
 	prometheus.MustRegister(m.Duration)


### PR DESCRIPTION
Huey recommends raising the CancelExecution exception to cancel/abort running tasks. There is no metric in prometheus-huey-exporter to count canceled tasks. This PR adds support and a simple counter for canceled events.

```
# HELP scheduler_task_canceled_total The Number of times a scheduler task has been canceled.
# TYPE scheduler_task_canceled_total counter
scheduler_task_canceled_total{task_name="huey_task"} 1
```